### PR TITLE
remove git_mod

### DIFF
--- a/R/shiny-data.R
+++ b/R/shiny-data.R
@@ -10,12 +10,7 @@ create_shiny_data <- function() {
   process_jhu_data()
   process_test_data()
 
-  # in case some countries have negative data, we exit early
-  git_mod <- gert::git_status()
-  git_mod <- git_mod[git_mod$status == "modified", ]
-  if (any("issues/coronavirus_tests_new_negative.csv" %in% git_mod$file)) {
-    return(invisible())
-  }
+  
   # country reference data -----------------------------------------------------
 
   country_name <-


### PR DESCRIPTION
When negative values are found in the file that Imane uploads,  the porcessed/coronavirus_tests.csv is not updated and this is a clear indication that we should correct the uploaded file (alson in the log of the action run).

The git_mod does not allow us to update the processed/data_all.csv file even after we upload a corrected file, since the file with the negative values is recently modified.