### PR TITLE
unify country names

### DIFF
--- a/R/shiny-data.R
+++ b/R/shiny-data.R
@@ -133,7 +133,7 @@ create_shiny_data <- function() {
       by = c("name" = "regex"), ignore_case = TRUE
     ) %>%
     mutate(country = case_when(
-      name == "Kosovo" ~ "XK",
+      name == "Kosovo" ~ "XKX",
       TRUE ~ country
     )) %>%
     # drop non countries


### PR DESCRIPTION
unify country names to fix [#136 ](https://github.com/dsbbfinddx/shinyfindapps/issues/136) in shinyfindapps. This helps countries like Congo - Kinshasa, Congo - Brazaville, Cote d'ivore, etc use the more accepted names of Democratic Republic of Congo, Republic of Congo, Ivory Coast, etc  in `data_all.csv`